### PR TITLE
Remove `spanned`

### DIFF
--- a/proc-macro-warning/src/lib.rs
+++ b/proc-macro-warning/src/lib.rs
@@ -10,7 +10,7 @@
 use core::ops::Deref;
 use proc_macro2::Span;
 use quote::{quote_spanned, ToTokens};
-use syn::{spanned::Spanned, Ident};
+use syn::Ident;
 
 mod test;
 
@@ -158,12 +158,6 @@ impl DeprecatedWarningBuilder {
 	#[must_use]
 	pub fn span(self, span: Span) -> Self {
 		Self { span: Some(span), ..self }
-	}
-
-	/// Set the span of the warning to the span of `s`.
-	#[must_use]
-	pub fn spanned<S: Spanned>(self, spanned: S) -> Self {
-		Self { span: Some(spanned.span()), ..self }
 	}
 
 	/// Fallibly build a warning.

--- a/proc-macro-warning/src/test.rs
+++ b/proc-macro-warning/src/test.rs
@@ -69,15 +69,6 @@ fn type_inferring_into_string_works() {
 	test_into_string_inference!(Warning::new_deprecated("").help_link);
 }
 
-/// Check the functions that accepting `Spanned` work as expected.
-#[test]
-fn type_inferring_spanned_works() {
-	let ident = syn::Ident::new("foo", proc_macro2::Span::call_site());
-
-	let _ = Warning::new_deprecated("").spanned(&ident);
-	let _ = Warning::new_deprecated("").spanned(ident);
-}
-
 #[test]
 #[cfg(feature = "derive_debug")]
 fn warning_debug_works() {


### PR DESCRIPTION
Changes:
 - Remove `DeprecatedWarningBuilder::spanned`. Something with the `syn` features is getting messed up, so just deleting it.