### PR TITLE
Only lock deps major version

### DIFF
--- a/proc-macro-warning/Cargo.toml
+++ b/proc-macro-warning/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/ggwpez/proc-macro-warning"
 readme.workspace = true
 
 [dependencies]
-proc-macro2 = { version = "1.0.71", default-features = false }
-quote = { version = "1.0.33", default-features = false }
-syn = { version = "2.0.42", default-features = false }
+proc-macro2 = { version = "1.0", default-features = false }
+quote = { version = "1.0", default-features = false }
+syn = { version = "2.0", default-features = false }
 
 [dev-dependencies]
 derive = { path = "../ui-tests/derive" }


### PR DESCRIPTION
Only require the major version of all dependencies. This should allow downstream more flexibility to select the correct minor/patch.