### PR TITLE
Remove publish feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,16 +30,16 @@ jobs:
       run: cargo check --all-targets --no-default-features # still broken --locked
 
     - name: Build
-      run: cargo build --all-targets --features derive_debug --locked
+      run: cargo build --all-targets --all-features --locked
 
     - name: Test
-      run: cargo test --locked --all-targets --features derive_debug
+      run: cargo test --locked --all-targets --all-features
 
     - name: Clippy
-      run: cargo clippy --locked --all-targets --features derive_debug -- -D warnings
+      run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
     - name: Documentation
-      run: cargo doc --locked --no-deps --features derive_debug
+      run: cargo doc --locked --no-deps --all-features
 
     - name: Doc Test
       run: cargo test --locked --doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "proc-macro-warning"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "derive",
  "proc-macro2",

--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -7,8 +7,12 @@ Info regarding crate maintenance.
 The README file of the `proc-macro-warning` crate is not found during normal `cargo publish` invocation. We therefore always publish with the `publish` feature, that adapts the path for publishing.
 
 ```bash
+# Smoke screen check semver:
+cargo semver-checks -p proc-macro-warning
+# Replace the version here:
+git tag -s -a v1.0.1 -m "Version 1.0.1"
 # Check that it works
-cargo publish -p proc-macro-warning --features publish --dry-run
+cargo publish -p proc-macro-warning --dry-run
 # Actually do the publish
-cargo publish -p proc-macro-warning --features publish
+cargo publish -p proc-macro-warning
 ```

--- a/proc-macro-warning/Cargo.toml
+++ b/proc-macro-warning/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc-macro-warning"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 license = "GPL-3.0 OR Apache-2.0"
 authors = ["Oliver Tale-Yazdi <oliver@tasty.limo>"]
@@ -20,4 +20,3 @@ derive = { path = "../ui-tests/derive" }
 default = ["derive_debug"]
 
 derive_debug = []
-publish = []


### PR DESCRIPTION
The `publish` feature should not be needed anymore after #14.